### PR TITLE
allow to optimize jpeg files

### DIFF
--- a/Components/TinyPngOptimizer.php
+++ b/Components/TinyPngOptimizer.php
@@ -13,7 +13,8 @@ class TinyPngOptimizer implements OptimizerInterface
     /**
      * @var array
      */
-    public static $supportedMimeTypes = ['image/png'];
+    public static $supportedMimeTypes;
+
     /**
      * @var TinyPngService
      */
@@ -36,11 +37,12 @@ class TinyPngOptimizer implements OptimizerInterface
      * @param string         $rootDir
      * @param array          $pluginConfig
      */
-    public function __construct(TinyPngService $tinyPngService, $rootDir, array $pluginConfig)
+    public function __construct(TinyPngService $tinyPngService, string $rootDir, array $pluginConfig)
     {
         $this->tinyPngService = $tinyPngService;
         $this->rootDir = $rootDir;
         $this->pluginConfig = $pluginConfig;
+        self::$supportedMimeTypes = $pluginConfig['mimeTypes'];
     }
 
     /**

--- a/Resources/config.xml
+++ b/Resources/config.xml
@@ -33,7 +33,7 @@
         <element type="boolean">
             <name>optimizeOriginal</name>
             <label lang="de">Optimiere auch Originalbilder</label>
-            <label>optimize original images, too</label>
+            <label>Optimize original images, too</label>
             <value>true</value>
         </element>
         <element type="number">
@@ -41,6 +41,25 @@
             <label lang="de">Monatliches Limit</label>
             <label>Mountly limit</label>
             <value>500</value>
+        </element>
+        <element type="select">
+            <name>mimeTypes</name>
+            <label>Use for image formats</label>
+            <label lang="de">Nutze für Bildformate</label>
+            <value>image/png</value>
+            <store>
+                <option>
+                    <value>image/png</value>
+                    <label>PNG</label>
+                </option>
+                <option>
+                    <value>image/jpeg</value>
+                    <label>JPEG</label>
+                </option>
+            </store>
+            <options>
+                <multiSelect>true</multiSelect>
+            </options>
         </element>
     </elements>
 </config>

--- a/Resources/services.xml
+++ b/Resources/services.xml
@@ -19,7 +19,7 @@
 
         <service id="frosh_tinypng_optimizer.config" class="Shopware\Components\Plugin\CachedConfigReader">
             <factory service="shopware.plugin.cached_config_reader" method="getByPluginName"/>
-            <argument type="string">FroshTinyPngMediaOptimizer</argument>
+            <argument type="string">%frosh_tiny_png_media_optimizer.plugin_name%</argument>
         </service>
     </services>
 </container>


### PR DESCRIPTION
Hey Froshis,
I really like your TinyPNG integration. Mostly because it's not so invasive like the one in the community store. Happy to see that you already fixed the cached config reader, because the latest release of the plugin doesn't work at all.

Besides you're recommending another service to optimize jpeg images, there might be some ppl out there, who like to use TinyPng for this. Like me :)

This PR adds a configuration to allow jpeg optimization, too.