### PR TITLE
implement cache for api verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# PhpStorm files
+.idea
+
+# Git Files
+!.gitkeep
+!.htaccess

--- a/Components/TinyPngOptimizer.php
+++ b/Components/TinyPngOptimizer.php
@@ -55,6 +55,7 @@ class TinyPngOptimizer implements OptimizerInterface
      * @param string $filepath
      *
      * @throws TinyPngApiException
+     * @throws TinyPngPersistanceException
      */
     public function run($filepath)
     {
@@ -83,10 +84,7 @@ class TinyPngOptimizer implements OptimizerInterface
      */
     public function isRunnable()
     {
-        /*
-         * TODO: consider using cache
-         */
-        return $this->tinyPngService->verifyApiKey();
+        return $this->tinyPngService->verifyApiKey(true);
     }
 
     /**

--- a/Components/TinyPngPersistanceException.php
+++ b/Components/TinyPngPersistanceException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace FroshTinyPngMediaOptimizer\Components;
+
+/**
+ * Class TinyPngApiException
+ */
+class TinyPngPersistanceException extends \Exception
+{
+}

--- a/Components/TinyPngServiceFactory.php
+++ b/Components/TinyPngServiceFactory.php
@@ -2,17 +2,20 @@
 
 namespace FroshTinyPngMediaOptimizer\Components;
 
+use Shopware\Components\CacheManager;
+
 /**
- * Class OptimusServiceFactory
+ * Class TinyPngServiceFactory
  */
 class TinyPngServiceFactory
 {
     /**
-     * @param $pluginconfig
+     * @param array $config
+     * @param CacheManager $cacheManager
      * @return TinyPngService
      */
-    public static function factory($pluginconfig)
+    public static function factory(array $config, CacheManager $cacheManager)
     {
-        return new TinyPngService($pluginconfig['apiKey'], $pluginconfig['limit']);
+        return new TinyPngService($config['apiKey'], $config['limit'], $cacheManager->getCoreCache());
     }
 }

--- a/Resources/services.xml
+++ b/Resources/services.xml
@@ -8,6 +8,7 @@
         <service id="frosh_tinypng_optimizer.service" class="FroshTinyPngMediaOptimizer\Components\TinyPngService">
             <factory service="frosh_tinypng_optimizer.service_factory" method="factory"/>
             <argument type="service" id="frosh_tinypng_optimizer.config"/>
+            <argument type="service" id="shopware.cache_manager"/>
         </service>
 
         <service id="frosh_tinypng_optimizer.image_optimizer" class="FroshTinyPngMediaOptimizer\Components\TinyPngOptimizer">


### PR DESCRIPTION
I like the idea of using a cache for the api verification. This should speed up initial mass optimizations. But I think caching the thing could be difficult, if you're using your api key in other installations like wordpress. So I set the caching time to 1 hour. Maybe an even lower threshould would be more appropriate. Like 1 minute?