### PR TITLE
proper original image optimization

### DIFF
--- a/Components/TinyPngOptimizer.php
+++ b/Components/TinyPngOptimizer.php
@@ -64,10 +64,6 @@ class TinyPngOptimizer implements OptimizerInterface
         }
 
         $this->tinyPngService->optimize($filepath);
-
-        if ($this->pluginConfig['optimizeOriginal'] && $this->isRunnable()) {
-            $this->optimizeOriginalFiles();
-        }
     }
 
     /**
@@ -97,49 +93,5 @@ class TinyPngOptimizer implements OptimizerInterface
     public function isShopware53()
     {
         return version_compare(Shopware::VERSION, '5.3.0', '>=');
-    }
-
-    private function optimizeOriginalFiles()
-    {
-        $sql = "SELECT * FROM s_media where albumID<>-13 AND type='IMAGE' and path not like('%thumb_export%') and extension in('png') and userID<>-1 ORDER by id DESC LIMIT 0,10";
-
-        $mediaResource = \Shopware\Components\Api\Manager::getResource('media');
-        $mediaservice = Shopware()->Container()->get('shopware_media.media_service');
-
-        foreach (Shopware()->Db()->fetchAll($sql) as $media) {
-            $mediainfo = $mediaResource->getOne($media['id']);
-
-            $path = explode('/media', $mediainfo['path']);
-            $localfilepath = $this->rootDir . '/media' . $path[1];
-
-            $origFilesize = $mediaservice->getSize($mediainfo['path']);
-            $masse = getimagesize($mediainfo['path']);
-            $breite = (int) $masse[0];
-            $hoehe = (int) $masse[1];
-
-            if ($origFilesize > 0) {
-                if ($mediaservice->getAdapterType() === 'local') {
-                    $filepath = $localfilepath;
-                } else {
-                    $file = tmpfile();
-                    $filepath = stream_get_meta_data($file)['uri'];
-                    file_put_contents($filepath, $mediaservice->read($mediainfo['path']));
-                }
-
-                try {
-                    $this->tinyPngService->optimize($filepath);
-                    $filesize = filesize($filepath);
-                    Shopware()->Db()->query('UPDATE s_media SET file_size=?,userID=-1 WHERE id=?',
-                        [$filesize, $media['id']]);
-                } catch (\Exception $e) {
-                }
-
-                if ($mediaservice->getAdapterType() !== 'local') {
-                    $mediaservice->writeStream('/media' . $path[1], $file);
-                }
-            }
-        }
-
-        return true;
     }
 }

--- a/Resources/services.xml
+++ b/Resources/services.xml
@@ -21,5 +21,13 @@
             <factory service="shopware.plugin.cached_config_reader" method="getByPluginName"/>
             <argument type="string">FroshTinyPngMediaOptimizer</argument>
         </service>
+
+        <service id="frosh_tinypng_optimizer.subscriber.media_model" class="FroshTinyPngMediaOptimizer\Subscriber\MediaModel">
+            <tag name="shopware.event_subscriber" />
+            <argument type="service" id="frosh_tinypng_optimizer.config"/>
+            <argument type="service" id="shopware_media.optimizer_service"/>
+            <argument type="service" id="shopware_media.media_service"/>
+            <argument>%kernel.root_dir%</argument>
+        </service>
     </services>
 </container>

--- a/Subscriber/MediaModel.php
+++ b/Subscriber/MediaModel.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace FroshTinyPngMediaOptimizer\Subscriber;
+
+use Enlight\Event\SubscriberInterface;
+use Shopware\Bundle\MediaBundle\MediaServiceInterface;
+use Shopware\Bundle\MediaBundle\OptimizerServiceInterface;
+use Symfony\Component\HttpFoundation\File\File;
+
+class MediaModel implements SubscriberInterface
+{
+    /**
+     * @var array
+     */
+    private $config;
+
+    /**
+     * @var OptimizerServiceInterface
+     */
+    private $optimizerService;
+
+    /**
+     * @var MediaServiceInterface
+     */
+    private $mediaService;
+
+    /**
+     * @param array $config
+     * @param OptimizerServiceInterface $optimizerService
+     * @param MediaServiceInterface $mediaService
+     */
+    public function __construct(array $config, OptimizerServiceInterface $optimizerService, MediaServiceInterface $mediaService)
+    {
+        $this->config = $config;
+        $this->optimizerService = $optimizerService;
+        $this->mediaService = $mediaService;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            'Shopware\Models\Media\Media::prePersist' => 'optimizeOriginalImage',
+        ];
+    }
+
+    public function optimizeOriginalImage(\Enlight_Event_EventArgs $args)
+    {
+        /** @var \Shopware\Models\Media\Media $media */
+        $media = $args->getEntity();
+
+        if(!$this->config['optimizeOriginal'] && $this->mediaService->has($media->getPath()))
+            return;
+
+        $basePath = $this->mediaService->getFilesystem()->getAdapter()->getPathPrefix();
+        $realPath = $basePath . $this->mediaService->encode($media->getPath());
+        $this->optimizerService->optimize($realPath);
+        $media->setFile(new File($realPath));
+    }
+}


### PR DESCRIPTION
I the current implementation is a but clumsy. You're not just optimizing the current image, you're optimizing the latest 10 images?!?
I think moving this to the media prePersist event is more elegant.